### PR TITLE
[CHORE] 혼자 패킹리스트 삭제 시 folder와의 연결 끊기

### DIFF
--- a/src/services/AloneListService.ts
+++ b/src/services/AloneListService.ts
@@ -198,6 +198,14 @@ const deleteAloneList = async (
 
     await client.query(
       `
+        DELETE
+        FROM "folder_packing_list" fpl
+        WHERE fpl.list_id IN (${aloneListIdArray})
+      `,
+    );
+
+    await client.query(
+      `
         UPDATE "packing_list"
         SET is_deleted=true
         WHERE id IN (${aloneListIdArray})


### PR DESCRIPTION
## 🌱 Related Issue
- Close #137 

## ✏️ Task
- 혼자패킹리스트 삭제 시 folder_packing_list의 해당 리스트 id 튜플 삭제

## 💡 Review Point
- 